### PR TITLE
bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
 - Use docker instead fo binaries #21
 - size vagrant box to runner in github actions #23
 - Sync origin template #28
-- Bumped version for minio, hive and postgres #34
+- Bumped version minio: 0.0.2 -> 0.1.0
+- Bumped version hive: 0.0.2 -> 0.1.0
+- Bumped version postgres: 0.0.1 -> 0.1.0
 - Consul Connect plugin optional with configurable artifact source #30
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Use docker instead fo binaries #21
 - size vagrant box to runner in github actions #23
 - Sync origin template #28
-- Bumped version for terraform-minio-module 0.0.3 -> 0.1.0 #34
+- Bumped version for minio and postgres #34
 - Consul Connect plugin optional with configurable artifact source #30
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Use docker instead fo binaries #21
 - size vagrant box to runner in github actions #23
 - Sync origin template #28
-- Bumped version for minio and postgres #34
+- Bumped version for minio, hive and postgres #34
 - Consul Connect plugin optional with configurable artifact source #30
 
 ## Fixed

--- a/example/main.tf
+++ b/example/main.tf
@@ -94,7 +94,7 @@ module "postgres" {
 }
 
 module "hive" {
-  source = "github.com/fredrikhgrelland/terraform-nomad-hive.git?ref=0.0.2"
+  source = "github.com/fredrikhgrelland/terraform-nomad-hive.git?ref=0.1.0"
 
   # nomad
   nomad_datacenters = local.nomad_datacenters

--- a/example/main.tf
+++ b/example/main.tf
@@ -84,13 +84,13 @@ module "postgres" {
   nomad_namespace   = local.nomad_namespace
 
   # postgres
-  postgres_service_name                    = "postgres"
-  postgres_container_image                 = "postgres:12-alpine"
-  postgres_container_port                  = 5432
-  postgres_admin_user                      = "hive"
-  postgres_admin_password                  = "hive"
-  postgres_database                        = "metastore"
-  postgres_container_environment_variables = ["PGDATA=/var/lib/postgresql/data"]
+  service_name                    = "postgres"
+  container_image                 = "postgres:12-alpine"
+  container_port                  = 5432
+  admin_user                      = "hive"
+  admin_password                  = "hive"
+  database                        = "metastore"
+  container_environment_variables = ["PGDATA=/var/lib/postgresql/data"]
 }
 
 module "hive" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -77,7 +77,7 @@ module "minio" {
 }
 
 module "postgres" {
-  source = "github.com/fredrikhgrelland/terraform-nomad-postgres.git?ref=0.0.1"
+  source = "github.com/fredrikhgrelland/terraform-nomad-postgres.git?ref=0.1.0"
 
   # nomad
   nomad_datacenters = local.nomad_datacenters


### PR DESCRIPTION
Closes #34 

Bump version for postgres -> 0.1.0
Bump version for hive -> 0.1.0