### PR TITLE
Add variable `hive_config_properties` for custom hive configuration properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Improve credentials management (vault provided credentials) #64
-- Added config (for add/rename/drop tables and columns) in presto-standalone #90
+- Added config (for add/rename/drop tables and columns) for presto-standalone #90
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Improve credentials management (vault provided credentials) #64
-- Added config (for add/rename/drop tables and columns and compression=ZSTD) for presto-standalone #90
+- Added variable `hive_config_properties` regarding custom hive configuration properties #90
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Improve credentials management (vault provided credentials) #64
-- Added variable `hive_config_properties` regarding custom hive configuration properties #90
+- Added variable `hive_config_properties` for custom hive configuration properties #90
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Improve credentials management (vault provided credentials) #64
-- Added config (for add/rename/drop tables and columns) for presto-standalone #90
+- Added config (for add/rename/drop tables and columns and compression=ZSTD) for presto-standalone #90
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Improve credentials management (vault provided credentials) #64
+- Added config (for add/rename/drop tables and columns) in presto-standalone #90
 
 ## [0.3.0]
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ module "presto" {
 | docker_image | Presto docker image | string | "prestosql/presto:341" | yes |
 | local_docker_image | Switch for Nomad jobs to use artifact for image lookup | bool | false | no |
 | container_environment_variables | Presto environment variables | list(string) | [""] | no |
+| hive_config_properties | Custom hive configuration properties | list(string) | [""] | no |
 | workers | cluster: Number of Nomad worker nodes | number | 1 | no |
 | coordinator | Include a coordinator in addition to the workers. Set this to `false` when extending an existing cluster | bool | true | no |
 | use_canary | Uses canary deployment for Presto | bool | false | no |

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ module "presto" {
   consul_http_addr = "http://10.0.3.10:8500"
   debug            = true
   use_canary       = true
+  hive_config_properties = [
+      "hive.allow-drop-table=true",
+      "hive.allow-rename-table=true",
+      "hive.allow-add-column=true",
+      "hive.allow-drop-column=true",
+      "hive.allow-rename-column=true",
+    "hive.compression-codec=ZSTD"]
 
   # other
   hivemetastore_service = {

--- a/conf/nomad/presto.hcl
+++ b/conf/nomad/presto.hcl
@@ -213,7 +213,7 @@ hive.s3.socket-timeout=31m
 hive.s3.ssl.enabled=false
 hive.metastore-timeout=1m
 hive.s3.path-style-access=true
-# Costum hive configuration properties
+# Custom hive configuration properties
 ${hive_config_properties}
 EOH
         destination = "local/presto/hive.properties"

--- a/conf/nomad/presto.hcl
+++ b/conf/nomad/presto.hcl
@@ -213,6 +213,8 @@ hive.s3.socket-timeout=31m
 hive.s3.ssl.enabled=false
 hive.metastore-timeout=1m
 hive.s3.path-style-access=true
+# Costum hive configuration properties
+${hive_config_properties}
 EOH
         destination = "local/presto/hive.properties"
       }

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,7 +208,7 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
-{{ if (len .hive_config_properties) > 0 }}
+{{ with "${hive_config_properties}" }}
 ${hive_config_properties}
 {{ end }}
 EOH

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,6 +208,12 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+hive.compression-codec=ZSTD
 EOH
       }
       template {

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,9 +208,8 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
-{{ with "${hive_config_properties}" }}
+{{/* Costum hive configuration properties */ }}
 ${hive_config_properties}
-{{ end }}
 EOH
       }
       template {

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,7 +208,7 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
-# Costum hive configuration properties
+# Custom hive configuration properties
 ${hive_config_properties}
 EOH
       }

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,7 +208,7 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
-{{/* Costum hive configuration properties */ }}
+# Costum hive configuration properties
 ${hive_config_properties}
 EOH
       }

--- a/conf/nomad/presto_standalone.hcl
+++ b/conf/nomad/presto_standalone.hcl
@@ -208,12 +208,9 @@ hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_${minio_service_name}" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
 hive.s3.socket-timeout=15m
-hive.allow-drop-table=true
-hive.allow-rename-table=true
-hive.allow-add-column=true
-hive.allow-drop-column=true
-hive.allow-rename-column=true
-hive.compression-codec=ZSTD
+{{ if (len .hive_config_properties) > 0 }}
+${hive_config_properties}
+{{ end }}
 EOH
       }
       template {

--- a/example/presto_standalone/main.tf
+++ b/example/presto_standalone/main.tf
@@ -35,7 +35,7 @@ module "presto" {
     "hive.allow-add-column=true",
     "hive.allow-drop-column=true",
     "hive.allow-rename-column=true",
-    "hive.compression-codec=ZSTD" ]
+  "hive.compression-codec=ZSTD"]
 
   resource = {
     cpu    = 500

--- a/example/presto_standalone/main.tf
+++ b/example/presto_standalone/main.tf
@@ -29,13 +29,13 @@ module "presto" {
   consul_http_addr = "http://10.0.3.10:8500"
   debug            = true
   use_canary       = true
-  hive_config_properties = [
-    "hive.allow-drop-table=true",
-    "hive.allow-rename-table=true",
-    "hive.allow-add-column=true",
-    "hive.allow-drop-column=true",
-    "hive.allow-rename-column=true",
-    "hive.compression-codec=ZSTD" ]
+//  hive_config_properties = [
+//    "hive.allow-drop-table=true",
+//    "hive.allow-rename-table=true",
+//    "hive.allow-add-column=true",
+//    "hive.allow-drop-column=true",
+//    "hive.allow-rename-column=true",
+//    "hive.compression-codec=ZSTD" ]
 
   resource = {
     cpu    = 500

--- a/example/presto_standalone/main.tf
+++ b/example/presto_standalone/main.tf
@@ -29,13 +29,13 @@ module "presto" {
   consul_http_addr = "http://10.0.3.10:8500"
   debug            = true
   use_canary       = true
-//  hive_config_properties = [
-//    "hive.allow-drop-table=true",
-//    "hive.allow-rename-table=true",
-//    "hive.allow-add-column=true",
-//    "hive.allow-drop-column=true",
-//    "hive.allow-rename-column=true",
-//    "hive.compression-codec=ZSTD" ]
+  hive_config_properties = [
+    "hive.allow-drop-table=true",
+    "hive.allow-rename-table=true",
+    "hive.allow-add-column=true",
+    "hive.allow-drop-column=true",
+    "hive.allow-rename-column=true",
+    "hive.compression-codec=ZSTD" ]
 
   resource = {
     cpu    = 500

--- a/example/presto_standalone/main.tf
+++ b/example/presto_standalone/main.tf
@@ -11,7 +11,6 @@ module "presto" {
     module.hive
   ]
 
-
   # nomad
   nomad_job_name    = "presto"
   nomad_datacenters = local.nomad_datacenters
@@ -30,6 +29,13 @@ module "presto" {
   consul_http_addr = "http://10.0.3.10:8500"
   debug            = true
   use_canary       = true
+  hive_config_properties = [
+    "hive.allow-drop-table=true",
+    "hive.allow-rename-table=true",
+    "hive.allow-add-column=true",
+    "hive.allow-drop-column=true",
+    "hive.allow-rename-column=true",
+    "hive.compression-codec=ZSTD" ]
 
   resource = {
     cpu    = 500

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ locals {
       "EXAMPLE_ENV=some-value",
     ], var.container_environment_variables)
   )
+  hive_config_properties = join("\n",
+  concat(var.hive_config_properties)
+  )
 
   template_standalone       = file("${path.module}/conf/nomad/presto_standalone.hcl")
   template_cluster          = file("${path.module}/conf/nomad/presto.hcl")
@@ -47,6 +50,7 @@ data "template_file" "template_nomad_job_presto" {
     workers                   = var.workers
     docker_image              = var.docker_image
     envs                      = local.presto_env_vars
+    hive_config_properties    = local.hive_config_properties
     debug                     = var.debug
     memory                    = var.resource.memory
     cpu                       = var.resource.cpu

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
     ], var.container_environment_variables)
   )
   hive_config_properties = join("\n",
-  concat(var.hive_config_properties)
+    concat(var.hive_config_properties)
   )
 
   template_standalone       = file("${path.module}/conf/nomad/presto_standalone.hcl")

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "resource_proxy" {
 
 variable "hive_config_properties" {
   type        = list(string)
-  description = "Hive configuration properties"
+  description = "Costum hive configuration properties"
   default     = [""]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "resource_proxy" {
 
 variable "hive_config_properties" {
   type        = list(string)
-  description = "Costum hive configuration properties"
+  description = "Custom hive configuration properties"
   default     = [""]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,13 @@ variable "resource_proxy" {
     error_message = "Proxy resource must be at least: cpu=200, memory=128."
   }
 }
+
+variable "hive_config_properties" {
+  type        = list(string)
+  description = "Hive configuration properties"
+  default     = [""]
+}
+
 ######
 # Service dependencies
 ######


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #90 

## What was added/changed/fixed?
Added variable `hive_config_properties` to [variables.tf](https://github.com/fredrikhgrelland/terraform-nomad-presto/blob/master/variables.tf) for custom hive configuration properties. The properties will be appended to `hive.properties` in the respective hcl-file (either [presto.hcl](https://github.com/fredrikhgrelland/terraform-nomad-presto/blob/master/conf/nomad/presto.hcl) or [presto-standalone.hcl](https://github.com/hannemariavister/terraform-nomad-presto/blob/master/conf/nomad/presto_standalone.hcl)).

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone